### PR TITLE
Fix estimator in BaggingPuClassifier

### DIFF
--- a/pulearn/bagging.py
+++ b/pulearn/bagging.py
@@ -215,7 +215,7 @@ class BaseBaggingPU(with_metaclass(ABCMeta, BaseEnsemble)):
 
     @abstractmethod
     def __init__(self,
-                 base_estimator=None,
+                 estimator=None,
                  n_estimators=10,
                  max_samples=1.0,
                  max_features=1.0,
@@ -227,7 +227,7 @@ class BaseBaggingPU(with_metaclass(ABCMeta, BaseEnsemble)):
                  random_state=None,
                  verbose=0):
         super(BaseBaggingPU, self).__init__(
-            base_estimator=base_estimator,
+            estimator=estimator,
             n_estimators=n_estimators)
 
         self.max_samples = max_samples
@@ -543,7 +543,7 @@ class BaggingPuClassifier(BaseBaggingPU, ClassifierMixin):
 
     """
     def __init__(self,
-                 base_estimator=None,
+                 estimator=None,
                  n_estimators=10,
                  max_samples=1.0,
                  max_features=1.0,
@@ -556,7 +556,7 @@ class BaggingPuClassifier(BaseBaggingPU, ClassifierMixin):
                  verbose=0):
 
         super(BaggingPuClassifier, self).__init__(
-            base_estimator,
+            estimator,
             n_estimators=n_estimators,
             max_samples=max_samples,
             max_features=max_features,
@@ -742,7 +742,7 @@ class BaggingPuClassifier(BaseBaggingPU, ClassifierMixin):
         return np.log(self.predict_proba(X))
 
     @available_if(
-        lambda self: hasattr(self.base_estimator, "decision_function"))
+        lambda self: hasattr(self.estimator, "decision_function"))
     def decision_function(self, X):
         """Average of the decision functions of the base classifiers.
 

--- a/tests/test_bagging.py
+++ b/tests/test_bagging.py
@@ -111,9 +111,9 @@ def test_bagging_not_fitted(dataset):
 @pytest.mark.parametrize("kwargs_n_fit_kwargs", [
     {'kwargs': {'verbose': 2, 'max_samples': 4}},
     {'kwargs': {'n_jobs': 2}},
-    {'kwargs': {'base_estimator': KNeighborsClassifier()}},
+    {'kwargs': {'estimator': KNeighborsClassifier()}},
     {
-        'kwargs': {'base_estimator': SVC()},
+        'kwargs': {'estimator': SVC()},
         'fit_kwargs': {'sample_weight': N_SAMPLES * [1]},
     },
     {'kwargs': {'bootstrap': False, 'oob_score': False}},
@@ -134,7 +134,7 @@ def test_bagging_various_kwargs(dataset, kwargs_n_fit_kwargs):
 
 @pytest.mark.parametrize("kwargs_n_fit_kwargs", [
     {
-        'kwargs': {'base_estimator': KNeighborsClassifier()},
+        'kwargs': {'estimator': KNeighborsClassifier()},
         'fit_kwargs': {'sample_weight': N_SAMPLES * [1]},
     },
     {'kwargs': {'bootstrap': False}},
@@ -182,7 +182,7 @@ def test_bagging_bad_predict_log_proba_shape(dataset):
 
 def test_bagging_bad_shape_decision_function(dataset):
     X, y = dataset
-    pu_estimator = BaggingPuClassifier(base_estimator=SVC())
+    pu_estimator = BaggingPuClassifier(estimator=SVC())
     pu_estimator.fit(X, y)
     with pytest.raises(ValueError):
         pu_estimator.decision_function(X[:, :2])


### PR DESCRIPTION
<!-- STEP 1: Give the pull request a meaningful title. -->
### Which issue(s) does this Pull Request fix?
<!-- STEP 2: Replace the "000" with the issue ID this pull request resolves. -->
Continuation of PR: Pu bugfix #26 

### Details of the Pull Request
<!-- STEP 3: Add details/comments on the pull request. -->
fix for: `TypeError: BaggingPuClassifier.__init__() got an unexpected keyword argument 'base_estimator'`
As discussed in PR #26 got the corresponding instantiation of the Base class changed in sklearn´s `BaseForest` for the `BaggingPuClassifier`. I think it is a straight forward fix with just variable re-naming and all tests passed with 100% coverage (locally, my actions and also on my personal code where i use the BaggingPuClassifier). Thanks for your discussion in #26 , it was quite straight forward with this nice help!

<!-- STEP 4: If the pull request is in progress, click the down green arrow to select "Create Draft Pull Request", and click the button. If the pull request is ready to be reviewed, click "Create Pull Request" button directly. -->
