### PR TITLE
Release: bump project version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "pulearn"
-version = "0.0.12"
+version = "0.1.1"
 description = "Positive-unlabeled learning with Python"
 readme = "README.rst"
 keywords = [


### PR DESCRIPTION
## Summary
- bump `project.version` in `pyproject.toml` from `0.0.12` to `0.1.1`
- prepare next PyPI release via the existing `release.yml` workflow (publishes on merge to `master` when version changes)

## Validation
- `PYTHONPATH=src python -m pytest tests/test_version.py`

## Notes
- latest published GitHub release is `v0.1.0`; this bump advances to the next patch release.
