### PR TITLE
Implement canonical PU label normalization utilities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,8 @@ These wrap the Python code from `a fork by AdityaAS <https://github.com/AdityaAS
 PU labels are normalized to a canonical internal representation
 (``1`` = labeled positive, ``0`` = unlabeled). Accepted input conventions
 include ``{1, -1}``, ``{1, 0}``, and ``{True, False}``.
+Use ``pulearn.normalize_pu_labels(...)`` to normalize labels immediately at
+ingest or estimator/metric boundaries.
 
 Classic Elkanoto
 ~~~~~~~~~~~~~~~~

--- a/src/pulearn/__init__.py
+++ b/src/pulearn/__init__.py
@@ -13,6 +13,9 @@ from .bagging import (  # noqa: F401
 )
 from .base import (  # noqa: F401
     BasePUClassifier,
+    normalize_pu_labels,
+    normalize_pu_y,
+    pu_label_masks,
 )
 from .bayesian_pu import (  # noqa: F401
     PositiveNaiveBayesClassifier,

--- a/src/pulearn/base.py
+++ b/src/pulearn/base.py
@@ -63,7 +63,27 @@ def normalize_pu_y(
     require_unlabeled=False,
     strict=True,
 ):
-    """Normalize PU labels to the canonical 0/1 representation."""
+    """Backward-compatible alias for :func:`normalize_pu_labels`."""
+    return normalize_pu_labels(
+        y,
+        positive_label=positive_label,
+        unlabeled_labels=unlabeled_labels,
+        require_positive=require_positive,
+        require_unlabeled=require_unlabeled,
+        strict=strict,
+    )
+
+
+def normalize_pu_labels(
+    y,
+    *,
+    positive_label=1,
+    unlabeled_labels=_DEFAULT_UNLABELED_LABELS,
+    require_positive=True,
+    require_unlabeled=False,
+    strict=True,
+):
+    """Normalize PU labels to canonical integer labels (1/0)."""
     is_positive, is_unlabeled = pu_label_masks(
         y,
         positive_label=positive_label,
@@ -85,7 +105,7 @@ def normalize_pu_y(
             )
         )
 
-    return is_positive.astype(int)
+    return is_positive.astype(np.int8, copy=False)
 
 
 class BasePUClassifier(ClassifierMixin, BaseEstimator):
@@ -118,7 +138,7 @@ class BasePUClassifier(ClassifierMixin, BaseEstimator):
         unlabeled_labels=_DEFAULT_UNLABELED_LABELS,
     ):
         """Normalize PU labels to the canonical 0/1 representation."""
-        return normalize_pu_y(
+        return normalize_pu_labels(
             y,
             positive_label=positive_label,
             unlabeled_labels=unlabeled_labels,

--- a/src/pulearn/documentation.md
+++ b/src/pulearn/documentation.md
@@ -25,6 +25,8 @@ Core PU classifiers now share a common base contract via
 - Shared PU label normalization utilities with canonical internal form
   (`1` = labeled positive, `0` = unlabeled). Inputs in `{1, -1}`,
   `{1, 0}`, and `{True, False}` are normalized immediately.
+  Use `pulearn.normalize_pu_labels(...)` (or `pulearn.base.normalize_pu_y(...)`)
+  to convert labels at API boundaries.
 - Shared `predict_proba` output checks for shape and numeric validity.
 - Optional hooks for score calibration and PU scorer construction.
 

--- a/src/pulearn/metrics.py
+++ b/src/pulearn/metrics.py
@@ -29,7 +29,7 @@ import numpy as np
 from sklearn.metrics import make_scorer as _make_scorer
 from sklearn.metrics import roc_auc_score as _roc_auc_score
 
-from pulearn.base import pu_label_masks
+from pulearn.base import normalize_pu_labels
 
 # Module-level numeric constants
 _LOGISTIC_LOSS_EPS = 1e-15  # clip range for logistic loss
@@ -68,7 +68,14 @@ def _pu_masks(
 ):
     """Validate PU labels and return positive/unlabeled masks."""
     y_arr = _as_1d_array(y_pu, name="y_pu")
-    is_positive, is_unlabeled = pu_label_masks(y_arr, strict=True)
+    y_norm = normalize_pu_labels(
+        y_arr,
+        require_positive=False,
+        require_unlabeled=False,
+        strict=True,
+    )
+    is_positive = y_norm == 1
+    is_unlabeled = y_norm == 0
     if require_positive and not np.any(is_positive):
         raise ValueError(
             "No labeled positive samples found (y_pu == 1). Cannot {}.".format(
@@ -79,7 +86,7 @@ def _pu_masks(
         raise ValueError(
             "No unlabeled samples found. Cannot {}.".format(context)
         )
-    return y_arr, is_positive, is_unlabeled
+    return y_norm, is_positive, is_unlabeled
 
 
 def _positive_prediction_mask(y_pred, *, threshold):
@@ -89,8 +96,13 @@ def _positive_prediction_mask(y_pred, *, threshold):
         if not np.all(np.isfinite(y_pred_arr)):
             raise ValueError("y_pred must contain only finite values.")
         return y_pred_arr > threshold
-    pred_pos, _ = pu_label_masks(y_pred_arr, strict=True)
-    return pred_pos
+    y_norm = normalize_pu_labels(
+        y_pred_arr,
+        require_positive=False,
+        require_unlabeled=False,
+        strict=True,
+    )
+    return y_norm == 1
 
 
 def _score_array(y_score, *, name):
@@ -127,7 +139,11 @@ def recall(y_true: np.array, y_pred: np.array, threshold: float = 0.5):
         The recall score for the given input samples.
 
     """
-    y_true_arr = _as_1d_array(y_true, name="y_true")
+    y_true_arr, positive_samples, _ = _pu_masks(
+        y_true,
+        require_positive=True,
+        context="compute recall",
+    )
     y_pred_arr = _as_1d_array(y_pred, name="y_pred")
     _validate_same_length(
         y_true_arr,
@@ -135,12 +151,6 @@ def recall(y_true: np.array, y_pred: np.array, threshold: float = 0.5):
         lhs_name="y_true",
         rhs_name="y_pred",
     )
-    positive_samples, _ = pu_label_masks(y_true_arr, strict=True)
-    if not np.any(positive_samples):
-        raise ValueError(
-            "No labeled positive samples found (y_true == 1). "
-            "Cannot compute recall."
-        )
     pred_positive = _positive_prediction_mask(y_pred_arr, threshold=threshold)
     return float(np.mean(pred_positive[positive_samples]))
 

--- a/tests/test_api_foundations.py
+++ b/tests/test_api_foundations.py
@@ -1,6 +1,7 @@
 """Tests for shared API foundations and estimator contracts."""
 
 import numpy as np
+import pandas as pd
 import pytest
 from sklearn.datasets import make_classification
 from sklearn.ensemble import RandomForestClassifier
@@ -12,7 +13,7 @@ from pulearn import (
     NNPUClassifier,
     PositiveNaiveBayesClassifier,
 )
-from pulearn.base import normalize_pu_y, pu_label_masks
+from pulearn.base import normalize_pu_labels, normalize_pu_y, pu_label_masks
 
 
 class _DummyPUClassifier(BasePUClassifier):
@@ -96,6 +97,36 @@ def test_pu_label_masks_supported_conventions():
 def test_normalize_pu_y_rejects_invalid_labels():
     with pytest.raises(ValueError, match="Unsupported PU labels"):
         normalize_pu_y(np.array([1, 2, 0]))
+
+
+@pytest.mark.parametrize(
+    "labels,expected",
+    [
+        (np.array([1, 0, 1, 0]), np.array([1, 0, 1, 0], dtype=np.int8)),
+        (np.array([1, -1, 1, -1]), np.array([1, 0, 1, 0], dtype=np.int8)),
+        (
+            np.array([True, False, True, False], dtype=object),
+            np.array([1, 0, 1, 0], dtype=np.int8),
+        ),
+    ],
+)
+def test_normalize_pu_labels_supported_conventions(labels, expected):
+    normalized = normalize_pu_labels(labels)
+    np.testing.assert_array_equal(normalized, expected)
+    assert np.issubdtype(normalized.dtype, np.integer)
+
+
+def test_normalize_pu_labels_accepts_pandas_series():
+    labels = pd.Series([1, -1, 1, -1], dtype="int64")
+    normalized = normalize_pu_labels(labels)
+    np.testing.assert_array_equal(normalized, np.array([1, 0, 1, 0]))
+
+
+def test_normalize_pu_y_alias_matches_normalize_pu_labels():
+    labels = np.array([1, -1, 1, -1])
+    np.testing.assert_array_equal(
+        normalize_pu_y(labels), normalize_pu_labels(labels)
+    )
 
 
 def test_normalize_pu_y_rejects_mixed_invalid_object_labels():


### PR DESCRIPTION
## Summary
- add a canonical `normalize_pu_labels(...)` utility returning internal `1` (labeled positive) / `0` (unlabeled)
- keep `normalize_pu_y(...)` as a backward-compatible alias
- route shared estimator/metric label handling through the same normalization pathway
- export normalization helpers at package level and document boundary usage in README/docs
- add conversion/alias/pandas compatibility tests for supported conventions

## Validation
- `ruff check src/pulearn/base.py src/pulearn/metrics.py src/pulearn/__init__.py tests/test_api_foundations.py`
- `PYTHONPATH=src JOBLIB_MULTIPROCESSING=0 python -m pytest tests/test_api_foundations.py tests/test_metrics.py tests/test_pu_metrics_corrected.py tests/test_bagging.py`
- `PYTHONPATH=src JOBLIB_MULTIPROCESSING=0 python -m pytest`

Closes #107