### PR TITLE
Centralize edge-case validation across PU estimators and metrics

### DIFF
--- a/src/pulearn/base.py
+++ b/src/pulearn/base.py
@@ -21,6 +21,94 @@ def _stable_unique_values(values):
     return deduped
 
 
+def validate_non_empty_1d_array(values, *, name):
+    """Return a one-dimensional, non-empty NumPy array."""
+    arr = np.asarray(values)
+    if arr.ndim != 1:
+        raise ValueError(
+            "{} must be one-dimensional. Got shape {}.".format(name, arr.shape)
+        )
+    if arr.shape[0] == 0:
+        raise ValueError(
+            "{} must be non-empty. Received 0 samples.".format(name)
+        )
+    return arr
+
+
+def validate_same_sample_count(lhs, rhs, *, lhs_name, rhs_name):
+    """Ensure two arrays share the same sample count."""
+    lhs_size = np.shape(lhs)[0]
+    rhs_size = np.shape(rhs)[0]
+    if lhs_size != rhs_size:
+        raise ValueError(
+            "{} and {} must have the same length. Got {} and {}. "
+            "Ensure both arrays reference the same samples.".format(
+                lhs_name, rhs_name, lhs_size, rhs_size
+            )
+        )
+
+
+def validate_required_pu_labels(
+    is_positive,
+    is_unlabeled,
+    *,
+    require_positive,
+    require_unlabeled,
+    label_name,
+    positive_label=1,
+    unlabeled_labels=_DEFAULT_UNLABELED_LABELS,
+    context=None,
+):
+    """Validate required PU label presence with actionable messages."""
+    suffix = ""
+    if context:
+        suffix = " Cannot {}.".format(context)
+
+    if require_positive and not np.any(is_positive):
+        raise ValueError(
+            (
+                "No labeled positive samples found in {} "
+                "(expected {} == {}).{}"
+            ).format(
+                label_name,
+                label_name,
+                positive_label,
+                suffix,
+            )
+        )
+    if require_unlabeled and not np.any(is_unlabeled):
+        raise ValueError(
+            "No unlabeled samples found in {} (expected {} in {}).{}".format(
+                label_name,
+                label_name,
+                list(unlabeled_labels),
+                suffix,
+            )
+        )
+
+
+def validate_pu_fit_inputs(X, y, *, context="fit this estimator"):
+    """Validate common PU estimator input shape constraints."""
+    x_shape = np.shape(X)
+    if len(x_shape) != 2:
+        raise ValueError(
+            "X must be two-dimensional with shape (n_samples, n_features) "
+            "to {}. Got shape {}.".format(context, x_shape)
+        )
+    if x_shape[0] == 0:
+        raise ValueError(
+            "X must be non-empty to {}. Received 0 samples.".format(context)
+        )
+    y_arr = validate_non_empty_1d_array(y, name="y")
+    validate_same_sample_count(
+        X,
+        y_arr,
+        lhs_name="X",
+        rhs_name="y",
+    )
+    return y_arr
+
+
 def pu_label_masks(
     y,
     *,
@@ -29,13 +117,7 @@ def pu_label_masks(
     strict=True,
 ):
     """Return boolean masks for labeled positives and unlabeled samples."""
-    y_arr = np.asarray(y)
-    if y_arr.ndim != 1:
-        raise ValueError(
-            "PU labels must be one-dimensional. Got shape {}.".format(
-                y_arr.shape
-            )
-        )
+    y_arr = validate_non_empty_1d_array(y, name="y")
 
     is_positive = y_arr == positive_label
     is_unlabeled = np.isin(y_arr, unlabeled_labels)
@@ -90,20 +172,15 @@ def normalize_pu_labels(
         unlabeled_labels=unlabeled_labels,
         strict=strict,
     )
-
-    if require_positive and not np.any(is_positive):
-        raise ValueError(
-            "No positive examples found in y (positive label {}).".format(
-                positive_label
-            )
-        )
-
-    if require_unlabeled and not np.any(is_unlabeled):
-        raise ValueError(
-            "No unlabeled examples found (y in {}).".format(
-                list(unlabeled_labels)
-            )
-        )
+    validate_required_pu_labels(
+        is_positive,
+        is_unlabeled,
+        require_positive=require_positive,
+        require_unlabeled=require_unlabeled,
+        label_name="y",
+        positive_label=positive_label,
+        unlabeled_labels=unlabeled_labels,
+    )
 
     return is_positive.astype(np.int8, copy=False)
 

--- a/src/pulearn/bayesian_pu.py
+++ b/src/pulearn/bayesian_pu.py
@@ -31,7 +31,11 @@ from sklearn.utils.validation import (
     validate_data,
 )
 
-from pulearn.base import BasePUClassifier, pu_label_masks
+from pulearn.base import (
+    BasePUClassifier,
+    pu_label_masks,
+    validate_pu_fit_inputs,
+)
 
 __all__ = [
     "normalize_pu_labels",
@@ -250,19 +254,19 @@ class PositiveNaiveBayesClassifier(BasePUClassifier):
             examples.
 
         """
+        y = validate_pu_fit_inputs(
+            X,
+            y,
+            context="fit {}".format(self.__class__.__name__),
+        )
         X = validate_data(self, X)
-        y = np.asarray(y)
-        is_pos, is_unlab = self._pu_label_masks(y)
-        if not is_pos.any():
-            raise ValueError(
-                "No labeled positive examples found in y. "
-                "Labeled positives must be indicated by y == 1."
-            )
-        if not is_unlab.any():
-            raise ValueError(
-                "No unlabeled examples found in y. "
-                "Unlabeled examples must be indicated by y == 0 or y == -1."
-            )
+        y = self._normalize_pu_y(
+            y,
+            require_positive=True,
+            require_unlabeled=True,
+        )
+        is_pos = y == 1
+        is_unlab = y == 0
 
         self.classes_ = np.array([0, 1])
 
@@ -698,20 +702,19 @@ class PositiveTANClassifier(PositiveNaiveBayesClassifier):
             unlabeled examples.
 
         """
+        y = validate_pu_fit_inputs(
+            X,
+            y,
+            context="fit {}".format(self.__class__.__name__),
+        )
         X = validate_data(self, X)
-        y = np.asarray(y)
-        is_pos, is_unlab = self._pu_label_masks(y)
-        if not is_pos.any():
-            raise ValueError(
-                "No labeled positive examples found in y. "
-                "Labeled positives must be indicated by y == 1."
-            )
-        if not is_unlab.any():
-            raise ValueError(
-                "No unlabeled examples found in y. "
-                "Unlabeled examples must be indicated by "
-                "y == 0 or y == -1."
-            )
+        y = self._normalize_pu_y(
+            y,
+            require_positive=True,
+            require_unlabeled=True,
+        )
+        is_pos = y == 1
+        is_unlab = y == 0
 
         self.classes_ = np.array([0, 1])
 

--- a/src/pulearn/documentation.md
+++ b/src/pulearn/documentation.md
@@ -29,6 +29,9 @@ Core PU classifiers now share a common base contract via
   to convert labels at API boundaries.
 - Shared `predict_proba` output checks for shape and numeric validity.
 - Optional hooks for score calibration and PU scorer construction.
+- Shared validation policy for fit/metric inputs:
+  non-empty arrays, matching sample counts between arrays, and explicit
+  errors for missing labeled positives or missing unlabeled examples.
 
 ______________________________________________________________________
 

--- a/src/pulearn/elkanoto.py
+++ b/src/pulearn/elkanoto.py
@@ -4,7 +4,7 @@ import numpy as np
 from sklearn.exceptions import NotFittedError
 from sklearn.utils import check_random_state
 
-from pulearn.base import BasePUClassifier
+from pulearn.base import BasePUClassifier, validate_pu_fit_inputs
 
 
 class ElkanotoPuClassifier(BasePUClassifier):
@@ -57,6 +57,12 @@ class ElkanotoPuClassifier(BasePUClassifier):
             Returns self.
 
         """
+        y = validate_pu_fit_inputs(
+            X,
+            y,
+            context="fit ElkanotoPuClassifier",
+        )
+        X = np.asarray(X)
         y = self._normalize_pu_y(
             y,
             require_positive=True,
@@ -234,6 +240,12 @@ class WeightedElkanotoPuClassifier(BasePUClassifier):
             Returns self.
 
         """
+        y = validate_pu_fit_inputs(
+            X,
+            y,
+            context="fit WeightedElkanotoPuClassifier",
+        )
+        X = np.asarray(X)
         y = self._normalize_pu_y(
             y,
             require_positive=True,

--- a/src/pulearn/metrics.py
+++ b/src/pulearn/metrics.py
@@ -29,7 +29,12 @@ import numpy as np
 from sklearn.metrics import make_scorer as _make_scorer
 from sklearn.metrics import roc_auc_score as _roc_auc_score
 
-from pulearn.base import normalize_pu_labels
+from pulearn.base import (
+    normalize_pu_labels,
+    validate_non_empty_1d_array,
+    validate_required_pu_labels,
+    validate_same_sample_count,
+)
 
 # Module-level numeric constants
 _LOGISTIC_LOSS_EPS = 1e-15  # clip range for logistic loss
@@ -38,25 +43,17 @@ _KL_DIV_EPS = 1e-10  # smoothing for KL divergence histograms
 
 def _as_1d_array(values, *, name):
     """Validate and return a one-dimensional NumPy array."""
-    arr = np.asarray(values)
-    if arr.ndim != 1:
-        raise ValueError(
-            "{} must be one-dimensional. Got shape {}.".format(name, arr.shape)
-        )
-    return arr
+    return validate_non_empty_1d_array(values, name=name)
 
 
 def _validate_same_length(lhs, rhs, *, lhs_name, rhs_name):
     """Ensure two 1D arrays have matching length."""
-    if lhs.shape[0] != rhs.shape[0]:
-        raise ValueError(
-            "{} and {} must have the same length. Got {} and {}.".format(
-                lhs_name,
-                rhs_name,
-                lhs.shape[0],
-                rhs.shape[0],
-            )
-        )
+    validate_same_sample_count(
+        lhs,
+        rhs,
+        lhs_name=lhs_name,
+        rhs_name=rhs_name,
+    )
 
 
 def _pu_masks(
@@ -76,16 +73,14 @@ def _pu_masks(
     )
     is_positive = y_norm == 1
     is_unlabeled = y_norm == 0
-    if require_positive and not np.any(is_positive):
-        raise ValueError(
-            "No labeled positive samples found (y_pu == 1). Cannot {}.".format(
-                context
-            )
-        )
-    if require_unlabeled and not np.any(is_unlabeled):
-        raise ValueError(
-            "No unlabeled samples found. Cannot {}.".format(context)
-        )
+    validate_required_pu_labels(
+        is_positive,
+        is_unlabeled,
+        require_positive=require_positive,
+        require_unlabeled=require_unlabeled,
+        label_name="y_pu",
+        context=context,
+    )
     return y_norm, is_positive, is_unlabeled
 
 

--- a/src/pulearn/nnpu.py
+++ b/src/pulearn/nnpu.py
@@ -15,7 +15,7 @@ import numpy as np
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_is_fitted
 
-from pulearn.base import BasePUClassifier
+from pulearn.base import BasePUClassifier, validate_pu_fit_inputs
 
 try:
     from sklearn.utils.validation import validate_data
@@ -148,6 +148,7 @@ class NNPUClassifier(BasePUClassifier):
                 "prior must be in (0, 1), got {}.".format(self.prior)
             )
 
+        y = validate_pu_fit_inputs(X, y, context="fit NNPUClassifier")
         X, y = validate_data(self, X, y, dtype=float)
         y = self._normalize_pu_y(
             y,

--- a/tests/test_api_foundations.py
+++ b/tests/test_api_foundations.py
@@ -152,14 +152,26 @@ def test_pu_label_masks_non_strict_allows_unknown_labels():
     assert is_unlab.tolist() == [False, False, True]
 
 
+def test_base_pu_label_masks_helper_delegates():
+    clf = _DummyPUClassifier()
+    is_pos, is_unlab = clf._pu_label_masks(np.array([1, 0, -1]))
+    assert is_pos.tolist() == [True, False, False]
+    assert is_unlab.tolist() == [False, True, True]
+
+
 def test_normalize_pu_y_requires_unlabeled():
-    with pytest.raises(ValueError, match="No unlabeled examples found"):
+    with pytest.raises(ValueError, match="No unlabeled samples found"):
         normalize_pu_y(np.array([1, 1, 1]), require_unlabeled=True)
 
 
 def test_normalize_pu_y_requires_positive():
-    with pytest.raises(ValueError, match="No positive examples found"):
+    with pytest.raises(ValueError, match="No labeled positive samples found"):
         normalize_pu_y(np.array([0, -1, 0]), require_positive=True)
+
+
+def test_normalize_pu_y_rejects_empty_labels():
+    with pytest.raises(ValueError, match="must be non-empty"):
+        normalize_pu_y(np.array([]))
 
 
 def test_base_calibration_and_scorer_hooks():

--- a/tests/test_elkanoto_edge_cases.py
+++ b/tests/test_elkanoto_edge_cases.py
@@ -28,7 +28,60 @@ def test_elkanoto_no_positive_examples():
     estimator = SVC(C=10, kernel="rbf", gamma=0.4, probability=True)
     pu_estimator = ElkanotoPuClassifier(estimator)
 
-    with pytest.raises(ValueError, match="No positive examples found"):
+    with pytest.raises(ValueError, match="No labeled positive samples found"):
+        pu_estimator.fit(X, y)
+
+
+@pytest.mark.parametrize(
+    "Cls,kwargs",
+    [
+        (ElkanotoPuClassifier, {}),
+        (
+            WeightedElkanotoPuClassifier,
+            {"labeled": 20, "unlabeled": 20},
+        ),
+    ],
+)
+def test_elkanoto_rejects_mismatched_lengths(Cls, kwargs):
+    """Fail fast with a clear mismatch error for X/y length differences."""
+    X = np.random.RandomState(0).rand(10, 3)
+    y = np.array([1, -1, 1, -1, 1])
+    estimator = RandomForestClassifier(n_estimators=2, n_jobs=1)
+    pu_estimator = Cls(estimator=estimator, **kwargs)
+
+    with pytest.raises(ValueError, match="must have the same length"):
+        pu_estimator.fit(X, y)
+
+
+@pytest.mark.parametrize(
+    "Cls,kwargs",
+    [
+        (ElkanotoPuClassifier, {}),
+        (
+            WeightedElkanotoPuClassifier,
+            {"labeled": 20, "unlabeled": 20},
+        ),
+    ],
+)
+def test_elkanoto_rejects_empty_training_data(Cls, kwargs):
+    """Fail fast with a clear error when no training samples are provided."""
+    X = np.empty((0, 3))
+    y = np.array([])
+    estimator = RandomForestClassifier(n_estimators=2, n_jobs=1)
+    pu_estimator = Cls(estimator=estimator, **kwargs)
+
+    with pytest.raises(ValueError, match="X must be non-empty"):
+        pu_estimator.fit(X, y)
+
+
+def test_elkanoto_rejects_non_2d_training_data():
+    """Fail fast when X is not a 2D feature matrix."""
+    X = np.array([0.1, 0.2, 0.3, 0.4])
+    y = np.array([1, -1, 1, -1])
+    estimator = RandomForestClassifier(n_estimators=2, n_jobs=1)
+    pu_estimator = ElkanotoPuClassifier(estimator=estimator)
+
+    with pytest.raises(ValueError, match="X must be two-dimensional"):
         pu_estimator.fit(X, y)
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -64,6 +64,13 @@ def test_recall_rejects_non_1d_input():
         recall(y_true, y_pred)
 
 
+def test_recall_rejects_empty_input():
+    y_true = np.array([])
+    y_pred = np.array([])
+    with pytest.raises(ValueError, match="must be non-empty"):
+        recall(y_true, y_pred)
+
+
 def test_recall_rejects_nonfinite_float_predictions():
     y_true = np.array([1, 1, 0, 0])
     y_pred = np.array([0.8, np.nan, 0.3, 0.1])

--- a/tests/test_nnpu.py
+++ b/tests/test_nnpu.py
@@ -109,7 +109,7 @@ def test_nnpu_no_positives():
     X = rng.randn(50, 5)
     y = np.full(50, -1)
     clf = NNPUClassifier(prior=0.3, max_iter=5)
-    with pytest.raises(ValueError, match="No positive"):
+    with pytest.raises(ValueError, match="No labeled positive samples found"):
         clf.fit(X, y)
 
 


### PR DESCRIPTION
## Summary
- add shared validation helpers for non-empty 1D arrays, sample-count consistency, required PU label presence, and fit input shape checks
- route base label normalization and metrics checks through these shared validators for consistent, actionable error messages
- validate estimator fit inputs in Elkanoto, Weighted Elkanoto, Bayesian PU classifiers, and NNPU before training
- document the shared validation policy in API foundations docs
- add regression tests for empty labels, mismatched X/y lengths, non-2D fit input, and base helper delegation

## Validation
- `ruff check src/pulearn/base.py src/pulearn/bayesian_pu.py src/pulearn/documentation.md src/pulearn/elkanoto.py src/pulearn/metrics.py src/pulearn/nnpu.py tests/test_api_foundations.py tests/test_elkanoto_edge_cases.py tests/test_metrics.py tests/test_nnpu.py`
- `PYTHONPATH=src JOBLIB_MULTIPROCESSING=0 python -m pytest`

Closes #108