### PR TITLE
Update autofix workflow pin to merged reusable-workflow commit

### DIFF
--- a/.github/workflows/pre-commit-autofix-trigger.yml
+++ b/.github/workflows/pre-commit-autofix-trigger.yml
@@ -25,7 +25,7 @@ jobs:
         github.event.pull_request.user.type == 'Bot' ||
         endsWith(github.event.pull_request.user.login, '[bot]')
       )
-    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@ba3b562c9f5f540600d64d77cd549e9566febb21
+    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@71e7082cd184c23fe2a740721c59abdde301e740
     with:
       pr_number: ${{ github.event.pull_request.number }}
 
@@ -34,6 +34,6 @@ jobs:
       github.event_name == 'status' &&
       github.event.context == 'pre-commit.ci - pr' &&
       github.event.state == 'failure'
-    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@ba3b562c9f5f540600d64d77cd549e9566febb21
+    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@71e7082cd184c23fe2a740721c59abdde301e740
     with:
       head_sha: ${{ github.event.sha }}


### PR DESCRIPTION
## Summary
- update `.github/workflows/pre-commit-autofix-trigger.yml` to pin `shaypal5/pre-commit-ci-autofix-trigger` to merged commit `71e7082cd184c23fe2a740721c59abdde301e740`
- replace the stale branch SHA `ba3b562c9f5f540600d64d77cd549e9566febb21`

## Why
`pulearn` is currently pinned to `ba3b562...`, which was a pre-merge branch commit from `shaypal5/pre-commit-ci-autofix-trigger#8`.

That branch was later rebased/force-pushed, and the merged reusable workflow now lives at `71e7082...` on `main`. As a result, GitHub can no longer resolve the old SHA as a reusable workflow ref, producing:

- `workflow was not found`
- `.github/workflows/pre-commit-autofix-trigger.yml#L28`

This PR only updates the pin to the merged, reachable commit.