### PR TITLE
Use v1 for the autofix reusable workflow

### DIFF
--- a/.github/workflows/pre-commit-autofix-trigger.yml
+++ b/.github/workflows/pre-commit-autofix-trigger.yml
@@ -25,7 +25,7 @@ jobs:
         github.event.pull_request.user.type == 'Bot' ||
         endsWith(github.event.pull_request.user.login, '[bot]')
       )
-    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@71e7082cd184c23fe2a740721c59abdde301e740
+    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@552808ae39c92f5d487964a34fbbc6d449bdd9c1
     with:
       pr_number: ${{ github.event.pull_request.number }}
 
@@ -34,6 +34,6 @@ jobs:
       github.event_name == 'status' &&
       github.event.context == 'pre-commit.ci - pr' &&
       github.event.state == 'failure'
-    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@71e7082cd184c23fe2a740721c59abdde301e740
+    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@552808ae39c92f5d487964a34fbbc6d449bdd9c1
     with:
       head_sha: ${{ github.event.sha }}

--- a/.github/workflows/pre-commit-autofix-trigger.yml
+++ b/.github/workflows/pre-commit-autofix-trigger.yml
@@ -25,7 +25,7 @@ jobs:
         github.event.pull_request.user.type == 'Bot' ||
         endsWith(github.event.pull_request.user.login, '[bot]')
       )
-    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@552808ae39c92f5d487964a34fbbc6d449bdd9c1
+    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@v1
     with:
       pr_number: ${{ github.event.pull_request.number }}
 
@@ -34,6 +34,6 @@ jobs:
       github.event_name == 'status' &&
       github.event.context == 'pre-commit.ci - pr' &&
       github.event.state == 'failure'
-    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@552808ae39c92f5d487964a34fbbc6d449bdd9c1
+    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@v1
     with:
       head_sha: ${{ github.event.sha }}


### PR DESCRIPTION
## Summary
- update `.github/workflows/pre-commit-autofix-trigger.yml` to pin `shaypal5/pre-commit-ci-autofix-trigger` to `@v1`

## Why
`pre-commit-ci-autofix-trigger` now publishes immutable concrete releases such as `v1.0.2` and maintains the moving major tag `v1`. Using `@v1` gives `pulearn` the stable major line while still receiving compatible bug fixes automatically.

This replaces the previous commit-hash pin with the supported major-version ref.