### PR TITLE
Use dedicated token for pre-commit autofix workflow

### DIFF
--- a/.github/workflows/pre-commit-autofix-trigger.yml
+++ b/.github/workflows/pre-commit-autofix-trigger.yml
@@ -27,10 +27,10 @@ jobs:
       )
     uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@v1
     with:
-      checkout_ref: v1.0.3
+      checkout_ref: v1.0.4
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
-      access_token: ${{ secrets.PRE_COMMIT_CI_AUTOFIX_TOKEN }}
+      access_token: ${{ secrets.PRE_COMMIT_CI_AUTOFIX_TOKEN || github.token }}
 
   trigger_from_status:
     if: >-
@@ -39,7 +39,7 @@ jobs:
       github.event.state == 'failure'
     uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@v1
     with:
-      checkout_ref: v1.0.3
+      checkout_ref: v1.0.4
       head_sha: ${{ github.event.sha }}
     secrets:
-      access_token: ${{ secrets.PRE_COMMIT_CI_AUTOFIX_TOKEN }}
+      access_token: ${{ secrets.PRE_COMMIT_CI_AUTOFIX_TOKEN || github.token }}

--- a/.github/workflows/pre-commit-autofix-trigger.yml
+++ b/.github/workflows/pre-commit-autofix-trigger.yml
@@ -27,7 +27,10 @@ jobs:
       )
     uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@v1
     with:
+      checkout_ref: v1.0.3
       pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      access_token: ${{ secrets.PRE_COMMIT_CI_AUTOFIX_TOKEN }}
 
   trigger_from_status:
     if: >-
@@ -36,4 +39,7 @@ jobs:
       github.event.state == 'failure'
     uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@v1
     with:
+      checkout_ref: v1.0.3
       head_sha: ${{ github.event.sha }}
+    secrets:
+      access_token: ${{ secrets.PRE_COMMIT_CI_AUTOFIX_TOKEN }}


### PR DESCRIPTION
## Summary
- pass an explicit `access_token` secret into the reusable pre-commit autofix workflow
- pin the reusable workflow's internal checkout to `v1.0.3`

## Why
Copilot-authored PRs can run with a token that is able to read PR and check data but cannot write labels, which causes `403 Resource not accessible by integration` when the reusable workflow tries to add `pre-commit.ci autofix`.

This wires `secrets.PRE_COMMIT_CI_AUTOFIX_TOKEN` into the reusable workflow so `pulearn` can supply a stronger token for label writes. If that secret is not configured, the reusable workflow still falls back to the default token.

## Follow-up
To fully activate this fix, configure a repository or organization secret named `PRE_COMMIT_CI_AUTOFIX_TOKEN` with token permissions that can add labels on pull requests in `pulearn/pulearn`.