### PR TITLE
Use pre-commit.ci autofix trigger v1.0.5

### DIFF
--- a/.github/workflows/pre-commit-autofix-trigger.yml
+++ b/.github/workflows/pre-commit-autofix-trigger.yml
@@ -25,10 +25,12 @@ jobs:
         github.event.pull_request.user.type == 'Bot' ||
         endsWith(github.event.pull_request.user.login, '[bot]')
       )
-    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@v1
+    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@v1.0.5
     with:
-      checkout_ref: v1.0.4
+      checkout_ref: v1.0.5
       pr_number: ${{ github.event.pull_request.number }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
+      max_attempts_per_head_sha: 2
     secrets:
       access_token: ${{ secrets.PRE_COMMIT_CI_AUTOFIX_TOKEN || github.token }}
 
@@ -37,9 +39,10 @@ jobs:
       github.event_name == 'status' &&
       github.event.context == 'pre-commit.ci - pr' &&
       github.event.state == 'failure'
-    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@v1
+    uses: shaypal5/pre-commit-ci-autofix-trigger/.github/workflows/reusable-autofix-trigger.yml@v1.0.5
     with:
-      checkout_ref: v1.0.4
+      checkout_ref: v1.0.5
       head_sha: ${{ github.event.sha }}
+      max_attempts_per_head_sha: 2
     secrets:
       access_token: ${{ secrets.PRE_COMMIT_CI_AUTOFIX_TOKEN || github.token }}


### PR DESCRIPTION
## Summary

- Pin the downstream autofix-trigger caller workflow to `shaypal5/pre-commit-ci-autofix-trigger@v1.0.5`.
- Update the reusable workflow `checkout_ref` to `v1.0.5` so the internal checkout uses the fixed release.
- Pass `head_sha` from `pull_request_target` events and set `max_attempts_per_head_sha: 2` explicitly.

## Why

`v1.0.5` adds durable per-head-SHA attempt tracking and workflow serialization so `pre-commit.ci autofix` is applied at most twice per pushed PR commit. This is the fix for the repeated label loop seen on `pulearn/pulearn#223`.

## Validation

- Parsed `.github/workflows/pre-commit-autofix-trigger.yml` with Ruby YAML loader.

## Notes

- The existing permissions already include `issues: write`, `pull-requests: write`, `checks: read`, `statuses: read`, and `contents: read`, which are the required permissions for the released workflow.
- Repository currently has no open milestones, so none is assigned.