### PR TITLE
Prefer git and gh CLI in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,9 @@ doc/
 
 ## Tooling and workflow
 
-- Use repo-specific Git/GitHub MCP tools for git and GitHub operations.
+- Use standard `git` and `gh` CLI commands first for git and GitHub
+  operations. Use repo-specific Git/GitHub MCP tools only when the CLI has a
+  gap, the CLI is unavailable, or the user explicitly requests MCP usage.
 - Keep changes focused; avoid opportunistic refactors.
 - Do not edit generated or local artifact directories unless explicitly asked
   (`build/`, `dist/`, `.coverage`, `cov.xml`, `pulearn.egg-info/`).

--- a/LOCAL_AGENTS.example.md
+++ b/LOCAL_AGENTS.example.md
@@ -3,16 +3,16 @@
 Copy this file to `LOCAL_AGENTS.md` for machine-specific agent instructions.
 `LOCAL_AGENTS.md` is intentionally untracked.
 
-## Optional local MCP routing
+## Optional local tool routing
 
-- For this repo, prefer a repo-specific git MCP namespace such as
-  `<repo_git_mcp_namespace>` for git operations.
-- For GitHub operations, prefer a repo-specific namespace like
-  `<repo_github_mcp_namespace>` when available.
-- Fall back to shared (non-repo-specific) GitHub MCPs only when repo-specific
-  MCPs are unavailable.
+- Use standard `git` and `gh` CLI commands first for git and GitHub operations.
+- Use repo-specific git/GitHub MCP namespaces, such as
+  `<repo_git_mcp_namespace>` and `<repo_github_mcp_namespace>`, only when the
+  CLI has a gap, the CLI is unavailable, or the user explicitly requests MCP
+  usage.
 
 ## Optional local workflow preferences
 
-- Prefer MCP tools over shell when both are available.
+- Prefer shell commands for git/GitHub work unless one of the MCP exceptions
+  above applies.
 - Keep local secrets in environment variables, not in repository files.


### PR DESCRIPTION
## Summary\n- Update agent instructions to prefer standard git and gh CLI for git/GitHub operations.\n- Limit git/GitHub MCP usage to CLI gaps, unavailable CLI, or explicit user request.\n\n## Testing\n- Not run; documentation-only instruction update.