### PR TITLE
Add benchmark leaderboard exports

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -69,13 +69,18 @@ jobs:
           )
           from pulearn.benchmarks import (
               BenchmarkRunner,
+              build_leaderboard_document,
+              leaderboard_metric_scorers,
               load_pu_breast_cancer,
               make_pu_dataset,
+              write_leaderboard_csv,
+              write_leaderboard_json,
           )
 
           N_SAMPLES = int("${{ github.event.inputs.n_samples || '2000' }}")
           PI = float("${{ github.event.inputs.pi || '0.3' }}")
           C = float("${{ github.event.inputs.c || '0.5' }}")
+          COMMIT_SHA = "${{ github.sha }}"
 
           def build_elkanoto():
               return ElkanotoPuClassifier(
@@ -103,6 +108,7 @@ jobs:
           }
 
           runner = BenchmarkRunner(random_state=42)
+          leaderboard_scorers = leaderboard_metric_scorers()
 
           # Synthetic dataset
           runner.run(
@@ -111,6 +117,8 @@ jobs:
               pi=PI,
               c=C,
               dataset_name="synthetic",
+              problem_type="PU_SCAR",
+              metric_scorers=leaderboard_scorers,
           )
 
           # Breast cancer (real) dataset
@@ -123,6 +131,8 @@ jobs:
               y_true=y_true_bc,
               y_pu=y_pu_bc,
               dataset_name="breast_cancer",
+              problem_type="PU_SCAR",
+              metric_scorers=leaderboard_scorers,
           )
 
           md = runner.to_markdown()
@@ -130,6 +140,12 @@ jobs:
           sys.stdout.flush()
 
           runner.to_csv("benchmark_results.csv")
+          leaderboard_doc = build_leaderboard_document(
+              runner,
+              commit_sha=COMMIT_SHA,
+          )
+          write_leaderboard_json(leaderboard_doc, "leaderboard/latest.json")
+          write_leaderboard_csv(leaderboard_doc, "leaderboard/latest.csv")
 
           failed = [r for r in runner.results if r.error]
 
@@ -169,5 +185,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results-py${{ matrix.python-version }}
-          path: benchmark_results.csv
+          path: |
+            benchmark_results.csv
+            leaderboard/latest.json
+            leaderboard/latest.csv
           if-no-files-found: ignore

--- a/doc/benchmark_gating_policy.md
+++ b/doc/benchmark_gating_policy.md
@@ -91,6 +91,18 @@ GitHub Actions artifact named
 `benchmark-results-py<python-version>` (one artifact per matrix entry).
 These artifacts are retained for 14 days (GitHub default).
 
+The same artifact also contains static leaderboard exports:
+
+- `leaderboard/latest.json` — versioned machine-readable leaderboard
+  document with run metadata, environment metadata, corrected PU metrics,
+  benchmark-oracle metrics, warnings, and errors.
+- `leaderboard/latest.csv` — flattened CSV view of the same leaderboard rows.
+
+The `pu_*` metric columns are corrected PU metrics computed on the held-out
+PU labels. The `oracle_*` metric columns use benchmark ground-truth labels and
+are intended for controlled benchmark diagnostics, not for deployable PU
+evaluation.
+
 You can download artifacts from the nightly run's summary page under
 **Artifacts**.
 

--- a/src/pulearn/benchmarks/__init__.py
+++ b/src/pulearn/benchmarks/__init__.py
@@ -48,6 +48,15 @@ from .experiment import (  # noqa: F401
     load_run_artifacts,
     save_run_artifacts,
 )
+from .leaderboard import (  # noqa: F401
+    LEADERBOARD_SCHEMA_VERSION,
+    build_leaderboard_document,
+    iter_leaderboard_csv_rows,
+    leaderboard_metric_scorers,
+    validate_leaderboard_document,
+    write_leaderboard_csv,
+    write_leaderboard_json,
+)
 from .runner import (  # noqa: F401
     BenchmarkResult,
     BenchmarkRunner,

--- a/src/pulearn/benchmarks/experiment.py
+++ b/src/pulearn/benchmarks/experiment.py
@@ -61,9 +61,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 if TYPE_CHECKING:
     from pulearn.benchmarks.runner import BenchmarkRunner
 
-# Reuse the shared CSV fieldnames from runner to avoid duplication.
-from pulearn.benchmarks.runner import _CSV_FIELDNAMES
-
 __all__ = [
     "ExperimentConfig",
     "save_run_artifacts",
@@ -463,10 +460,10 @@ def save_run_artifacts(
     # ---- results.csv ---------------------------------------------------
     results_path = os.path.join(run_dir, "results.csv")
     with open(results_path, "w", newline="", encoding="utf-8") as fh:
-        writer = csv.DictWriter(fh, fieldnames=_CSV_FIELDNAMES)
+        writer = csv.DictWriter(fh, fieldnames=runner._csv_fieldnames())
         writer.writeheader()
         for r in runner.results:
-            writer.writerow(r.as_dict())
+            writer.writerow(runner._csv_row(r))
 
     # ---- summary.json --------------------------------------------------
     summary: Dict[str, Any] = {

--- a/src/pulearn/benchmarks/leaderboard.py
+++ b/src/pulearn/benchmarks/leaderboard.py
@@ -1,0 +1,356 @@
+"""Static leaderboard exports for benchmark results.
+
+This module converts :class:`~pulearn.benchmarks.BenchmarkRunner` output into
+a small, versioned document that can be published by GitHub Pages or uploaded
+as a CI artifact.  The document intentionally distinguishes corrected PU
+metrics from benchmark-oracle metrics computed with ground-truth labels.
+
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import json
+import math
+import os
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from pulearn.benchmarks.runner import BenchmarkResult, BenchmarkRunner
+from pulearn.metrics import (
+    pu_average_precision_score,
+    pu_f1_score,
+    pu_roc_auc_score,
+)
+
+LEADERBOARD_SCHEMA_VERSION = 1
+
+_METRIC_DEFINITIONS = {
+    "pu_f1": {
+        "kind": "corrected_pu",
+        "description": (
+            "Unbiased PU F1 computed from held-out PU labels using the "
+            "benchmark-known class prior."
+        ),
+    },
+    "pu_roc_auc": {
+        "kind": "corrected_pu",
+        "description": (
+            "Sakai-corrected PU ROC-AUC computed from held-out PU labels "
+            "using the benchmark-known class prior."
+        ),
+    },
+    "pu_average_precision": {
+        "kind": "corrected_pu",
+        "description": (
+            "PU Area Under Lift computed from held-out PU labels using the "
+            "benchmark-known class prior."
+        ),
+    },
+    "oracle_f1": {
+        "kind": "benchmark_oracle",
+        "description": (
+            "Plain F1 computed with benchmark ground-truth labels. This is "
+            "for controlled benchmark diagnostics, not deployable PU "
+            "evaluation."
+        ),
+    },
+    "oracle_roc_auc": {
+        "kind": "benchmark_oracle",
+        "description": (
+            "Plain ROC-AUC computed with benchmark ground-truth labels. This "
+            "is for controlled benchmark diagnostics, not deployable PU "
+            "evaluation."
+        ),
+    },
+}
+
+_CSV_FIELDNAMES = [
+    "name",
+    "dataset",
+    "problem_type",
+    "pi",
+    "c",
+    "n_samples",
+    "pu_f1",
+    "pu_roc_auc",
+    "pu_average_precision",
+    "oracle_f1",
+    "oracle_roc_auc",
+    "fit_time_s",
+    "predict_time_s",
+    "warnings",
+    "error",
+]
+
+
+def _utc_now() -> str:
+    """Return the current UTC timestamp in compact ISO 8601 form."""
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _json_number(value: Any):
+    """Return *value* as a JSON-safe finite number or ``None``."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        value_float = float(value)
+        if math.isfinite(value_float):
+            return value
+        return None
+    return value
+
+
+def leaderboard_metric_scorers() -> Dict[str, Callable]:
+    """Return corrected PU metric scorers used by leaderboard exports.
+
+    The generic benchmark runner owns model execution and oracle benchmark
+    metrics.  This scorer map keeps the public leaderboard metric policy in
+    the leaderboard layer, where future schemas can add or remove metrics
+    without changing the runner's core result contract.
+
+    """
+
+    def _pu_f1(*, y_pu, y_pred, pi, **_kwargs) -> float:
+        return pu_f1_score(y_pu, y_pred, pi)
+
+    def _pu_roc_auc(*, y_pu, y_score, pi, **_kwargs) -> float:
+        return pu_roc_auc_score(y_pu, y_score, pi)
+
+    def _pu_average_precision(*, y_pu, y_score, pi, **_kwargs) -> float:
+        return pu_average_precision_score(y_pu, y_score, pi)
+
+    return {
+        "pu_f1": _pu_f1,
+        "pu_roc_auc": _pu_roc_auc,
+        "pu_average_precision": _pu_average_precision,
+    }
+
+
+def _result_to_row(result: BenchmarkResult) -> Dict[str, Any]:
+    """Convert a benchmark result to a leaderboard row."""
+    metrics = {
+        metric_name: _json_number(result.extra_metrics.get(metric_name))
+        for metric_name in _METRIC_DEFINITIONS
+        if metric_name.startswith("pu_")
+    }
+    metrics.update(
+        {
+            "oracle_f1": _json_number(result.f1),
+            "oracle_roc_auc": _json_number(result.roc_auc),
+        }
+    )
+    return {
+        "name": result.name,
+        "dataset": result.dataset,
+        "problem_type": result.problem_type,
+        "pi": _json_number(result.pi),
+        "c": _json_number(result.c),
+        "n_samples": result.n_samples,
+        "metrics": metrics,
+        "timing": {
+            "fit_time_s": _json_number(result.fit_time_s),
+            "predict_time_s": _json_number(result.predict_time_s),
+        },
+        "warnings": list(result.warnings),
+        "error": result.error,
+    }
+
+
+def build_leaderboard_document(
+    runner: BenchmarkRunner,
+    *,
+    commit_sha: Optional[str] = None,
+    generated_at: Optional[str] = None,
+    title: str = "PUlearn benchmark leaderboard",
+) -> Dict[str, Any]:
+    """Build a versioned leaderboard document from a benchmark runner.
+
+    Parameters
+    ----------
+    runner : BenchmarkRunner
+        Runner with accumulated benchmark results.
+    commit_sha : str or None, default None
+        Git commit SHA associated with the run.  When omitted, the value is
+        left as ``None`` for callers that run outside CI.
+    generated_at : str or None, default None
+        Timestamp to store in the document.  Defaults to current UTC time.
+    title : str, default "PUlearn benchmark leaderboard"
+        Human-readable document title.
+
+    Returns
+    -------
+    dict
+        JSON-serialisable leaderboard document.
+
+    """
+    rows = [_result_to_row(result) for result in runner.results]
+    problem_types = sorted({row["problem_type"] for row in rows})
+    document = {
+        "schema_version": LEADERBOARD_SCHEMA_VERSION,
+        "title": title,
+        "generated_at": generated_at or _utc_now(),
+        "commit_sha": commit_sha,
+        "environment": runner.metadata.as_dict(),
+        "problem_types": problem_types,
+        "metric_definitions": _METRIC_DEFINITIONS,
+        "results": rows,
+    }
+    validate_leaderboard_document(document)
+    return document
+
+
+def validate_leaderboard_document(document: Dict[str, Any]) -> None:
+    """Validate the minimal leaderboard JSON contract.
+
+    Raises
+    ------
+    ValueError
+        If the document shape is not publishable by the static leaderboard.
+
+    """
+    required = {
+        "schema_version",
+        "generated_at",
+        "environment",
+        "metric_definitions",
+        "problem_types",
+        "results",
+    }
+    missing = sorted(required - set(document))
+    if missing:
+        raise ValueError(
+            "Leaderboard document is missing required keys: {}".format(
+                ", ".join(missing)
+            )
+        )
+    if document["schema_version"] != LEADERBOARD_SCHEMA_VERSION:
+        raise ValueError(
+            "Unsupported leaderboard schema_version: {!r}".format(
+                document["schema_version"]
+            )
+        )
+    if not isinstance(document["results"], list):
+        raise ValueError("Leaderboard 'results' must be a list.")
+    for index, row in enumerate(document["results"]):
+        _validate_row(row, index=index)
+
+
+def _validate_row(row: Dict[str, Any], *, index: int) -> None:
+    """Validate a single leaderboard row."""
+    required = {
+        "name",
+        "dataset",
+        "problem_type",
+        "pi",
+        "c",
+        "n_samples",
+        "metrics",
+        "timing",
+        "warnings",
+        "error",
+    }
+    missing = sorted(required - set(row))
+    if missing:
+        raise ValueError(
+            "Leaderboard row {} is missing required keys: {}".format(
+                index,
+                ", ".join(missing),
+            )
+        )
+    if not row["problem_type"]:
+        raise ValueError(
+            "Leaderboard row {} has empty problem_type.".format(index)
+        )
+    if not isinstance(row["metrics"], dict):
+        raise ValueError(
+            "Leaderboard row {} metrics must be a dict.".format(index)
+        )
+    metric_keys = {
+        "pu_f1",
+        "pu_roc_auc",
+        "pu_average_precision",
+        "oracle_f1",
+        "oracle_roc_auc",
+    }
+    missing_metrics = sorted(metric_keys - set(row["metrics"]))
+    if missing_metrics:
+        raise ValueError(
+            "Leaderboard row {} is missing metrics: {}".format(
+                index,
+                ", ".join(missing_metrics),
+            )
+        )
+    if not isinstance(row["warnings"], list):
+        raise ValueError(
+            "Leaderboard row {} warnings must be a list.".format(index)
+        )
+
+
+def write_leaderboard_json(
+    document: Dict[str, Any],
+    path: str,
+) -> None:
+    """Write a prebuilt leaderboard document to *path* as JSON."""
+    validate_leaderboard_document(document)
+    directory = os.path.dirname(os.path.abspath(path))
+    os.makedirs(directory, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(document, fh, indent=2, sort_keys=True, allow_nan=False)
+        fh.write("\n")
+
+
+def iter_leaderboard_csv_rows(
+    document: Dict[str, Any],
+) -> Iterable[Dict[str, Any]]:
+    """Yield flattened rows for leaderboard CSV output."""
+    validate_leaderboard_document(document)
+    for row in document["results"]:
+        metrics = row["metrics"]
+        timing = row["timing"]
+        yield {
+            "name": row["name"],
+            "dataset": row["dataset"],
+            "problem_type": row["problem_type"],
+            "pi": row["pi"],
+            "c": row["c"],
+            "n_samples": row["n_samples"],
+            "pu_f1": metrics["pu_f1"],
+            "pu_roc_auc": metrics["pu_roc_auc"],
+            "pu_average_precision": metrics["pu_average_precision"],
+            "oracle_f1": metrics["oracle_f1"],
+            "oracle_roc_auc": metrics["oracle_roc_auc"],
+            "fit_time_s": timing["fit_time_s"],
+            "predict_time_s": timing["predict_time_s"],
+            "warnings": " | ".join(row["warnings"]),
+            "error": row["error"] or "",
+        }
+
+
+def write_leaderboard_csv(
+    document: Dict[str, Any],
+    path: str,
+) -> None:
+    """Write a prebuilt leaderboard document to *path* as flattened CSV."""
+    validate_leaderboard_document(document)
+    directory = os.path.dirname(os.path.abspath(path))
+    os.makedirs(directory, exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=_CSV_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(iter_leaderboard_csv_rows(document))
+
+
+__all__: List[str] = [
+    "LEADERBOARD_SCHEMA_VERSION",
+    "build_leaderboard_document",
+    "iter_leaderboard_csv_rows",
+    "leaderboard_metric_scorers",
+    "validate_leaderboard_document",
+    "write_leaderboard_csv",
+    "write_leaderboard_json",
+]

--- a/src/pulearn/benchmarks/runner.py
+++ b/src/pulearn/benchmarks/runner.py
@@ -35,7 +35,7 @@ import io
 import sys
 import time
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence
 
@@ -150,6 +150,14 @@ class BenchmarkResult:
         Wall-clock fit time in seconds.
     predict_time_s : float
         Wall-clock predict time in seconds.
+    extra_metrics : dict
+        Optional additional metrics computed by caller-supplied metric
+        scorers.  Used by publishing layers such as the leaderboard exporter
+        to keep benchmark policy outside the generic runner.
+    problem_type : str
+        Benchmark problem family.  Defaults to ``"PU_SCAR"``.
+    warnings : list of str
+        Non-fatal warnings captured while running this benchmark row.
     error : str or None
         Non-empty when the run failed; contains the exception message.
 
@@ -164,6 +172,9 @@ class BenchmarkResult:
     roc_auc: float = float("nan")
     fit_time_s: float = float("nan")
     predict_time_s: float = float("nan")
+    extra_metrics: Dict[str, float] = field(default_factory=dict)
+    problem_type: str = "PU_SCAR"
+    warnings: List[str] = field(default_factory=list)
     error: Optional[str] = None
 
     def as_dict(self) -> dict:
@@ -178,6 +189,9 @@ class BenchmarkResult:
             "roc_auc": self.roc_auc,
             "fit_time_s": self.fit_time_s,
             "predict_time_s": self.predict_time_s,
+            "extra_metrics": dict(self.extra_metrics),
+            "problem_type": self.problem_type,
+            "warnings": list(self.warnings),
             "error": self.error or "",
         }
 
@@ -197,6 +211,8 @@ _CSV_FIELDNAMES = [
     "roc_auc",
     "fit_time_s",
     "predict_time_s",
+    "problem_type",
+    "warnings",
     "error",
 ]
 
@@ -264,6 +280,8 @@ class BenchmarkRunner:
         X: Optional[np.ndarray] = None,
         y_true: Optional[np.ndarray] = None,
         y_pu: Optional[np.ndarray] = None,
+        problem_type: str = "PU_SCAR",
+        metric_scorers: Optional[Dict[str, Callable]] = None,
     ) -> "BenchmarkRunner":
         """Run all estimators on a single dataset configuration.
 
@@ -287,6 +305,14 @@ class BenchmarkRunner:
         X, y_true, y_pu : ndarray or None
             Pre-built arrays (skip generation when all three are supplied).
             Must all be supplied together or all omitted.
+        problem_type : str, default "PU_SCAR"
+            Problem-family label stored in each result row.
+        metric_scorers : dict or None, default None
+            Optional mapping of metric name to callable.  Each callable is
+            invoked with keyword arguments ``y_true``, ``y_pu``, ``y_pred``,
+            ``y_score``, ``pi`` and ``c`` for the held-out split.  Metric
+            ``ValueError`` exceptions are captured as row warnings and stored
+            as ``NaN`` so one unsupported metric does not fail the entire run.
 
         Returns
         -------
@@ -320,23 +346,28 @@ class BenchmarkRunner:
             actual_pi = float(y_true.mean())
         else:
             actual_pi = float(y_true.mean())
+        actual_c = self._labeling_propensity(y_true, y_pu, fallback=c)
 
         X_train, X_test, y_true_train, y_true_test, y_pu_train, y_pu_test = (
             self._split(X, y_true, y_pu)
         )
+        scorers = {} if metric_scorers is None else dict(metric_scorers)
 
         for name, builder in estimator_builders.items():
             result = self._run_one(
                 name=name,
                 dataset=dataset_name,
                 pi=actual_pi,
-                c=c,
+                c=actual_c,
                 n_samples=len(y_true),
+                problem_type=problem_type,
                 builder=builder,
                 X_train=X_train,
                 X_test=X_test,
                 y_pu_train=y_pu_train,
+                y_pu_test=y_pu_test,
                 y_true_test=y_true_test,
+                metric_scorers=scorers,
             )
             self._results.append(result)
 
@@ -387,30 +418,20 @@ class BenchmarkRunner:
             File path to write.
 
         """
+        fieldnames = self._csv_fieldnames()
         with open(path, "w", newline="") as fh:
-            writer = csv.DictWriter(fh, fieldnames=_CSV_FIELDNAMES)
+            writer = csv.DictWriter(fh, fieldnames=fieldnames)
             writer.writeheader()
             for r in self._results:
-                row = r.as_dict()
-                # Format floats for readability.
-                for k in ("f1", "roc_auc", "fit_time_s", "predict_time_s"):
-                    v = row[k]
-                    if isinstance(v, float) and not np.isnan(v):
-                        row[k] = _FLOAT_FMT.format(v)
-                writer.writerow(row)
+                writer.writerow(self._csv_row(r))
 
     def to_csv_string(self) -> str:
         """Return results as a CSV-formatted string."""
         buf = io.StringIO()
-        writer = csv.DictWriter(buf, fieldnames=_CSV_FIELDNAMES)
+        writer = csv.DictWriter(buf, fieldnames=self._csv_fieldnames())
         writer.writeheader()
         for r in self._results:
-            row = r.as_dict()
-            for k in ("f1", "roc_auc", "fit_time_s", "predict_time_s"):
-                v = row[k]
-                if isinstance(v, float) and not np.isnan(v):
-                    row[k] = _FLOAT_FMT.format(v)
-            writer.writerow(row)
+            writer.writerow(self._csv_row(r))
         return buf.getvalue()
 
     def to_markdown(self) -> str:
@@ -497,6 +518,45 @@ class BenchmarkRunner:
             stratify=y_pu,
         )
 
+    def _csv_fieldnames(self) -> List[str]:
+        """Return CSV field names including any extra metric columns."""
+        metric_names = sorted(
+            {
+                metric_name
+                for result in self._results
+                for metric_name in result.extra_metrics
+            }
+        )
+        return list(_CSV_FIELDNAMES) + metric_names
+
+    def _csv_row(self, result: BenchmarkResult) -> dict:
+        """Return a flattened CSV row for a benchmark result."""
+        row = result.as_dict()
+        extra_metrics = row.pop("extra_metrics")
+        row["warnings"] = " | ".join(row["warnings"])
+        row.update(extra_metrics)
+        for key, value in list(row.items()):
+            if isinstance(value, float) and not np.isnan(value):
+                row[key] = _FLOAT_FMT.format(value)
+        return row
+
+    @staticmethod
+    def _labeling_propensity(
+        y_true: np.ndarray,
+        y_pu: np.ndarray,
+        *,
+        fallback: float,
+    ) -> float:
+        """Return realised labeling propensity from truth and PU labels."""
+        y_true_arr = np.asarray(y_true)
+        y_pu_arr = np.asarray(y_pu)
+        pos_mask = y_true_arr == 1
+        n_pos = int(np.sum(pos_mask))
+        if n_pos == 0:
+            return float(fallback)
+        n_labeled_pos = int(np.sum((y_pu_arr == 1) & pos_mask))
+        return float(n_labeled_pos / n_pos)
+
     def _run_one(
         self,
         *,
@@ -505,13 +565,30 @@ class BenchmarkRunner:
         pi: float,
         c: float,
         n_samples: int,
+        problem_type: str,
         builder: Callable,
         X_train: np.ndarray,
         X_test: np.ndarray,
         y_pu_train: np.ndarray,
+        y_pu_test: np.ndarray,
         y_true_test: np.ndarray,
+        metric_scorers: Dict[str, Callable],
     ) -> BenchmarkResult:
         """Fit one estimator and collect metrics, catching all exceptions."""
+        result_warnings: List[str] = []
+
+        def _metric_or_nan(label: str, func: Callable, **kwargs):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                try:
+                    value = float(func(**kwargs))
+                except ValueError as exc:
+                    result_warnings.append("{}: {}".format(label, exc))
+                    return float("nan")
+            for warning in caught:
+                result_warnings.append("{}: {}".format(label, warning.message))
+            return value
+
         try:
             from sklearn.metrics import f1_score, roc_auc_score
 
@@ -542,11 +619,11 @@ class BenchmarkRunner:
             unique_pred = np.unique(y_pred)
             unique_true = np.unique(y_true_test)
             if len(unique_pred) < 2 or len(unique_true) < 2:
-                warnings.warn(
-                    "[{}] Degenerate predictions; "
-                    "F1/AUC may be undefined.".format(name),
-                    stacklevel=2,
-                )
+                message = (
+                    "[{}] Degenerate predictions; F1/AUC may be undefined."
+                ).format(name)
+                result_warnings.append(message)
+                warnings.warn(message, stacklevel=2)
 
             f1 = float(f1_score(y_true_test, y_pred, zero_division=0))
             try:
@@ -554,16 +631,35 @@ class BenchmarkRunner:
             except ValueError:
                 auc = float("nan")
 
+            extra_metrics = {}
+            metric_kwargs = {
+                "y_true": y_true_test,
+                "y_pu": y_pu_test,
+                "y_pred": y_pred,
+                "y_score": y_score,
+                "pi": pi,
+                "c": c,
+            }
+            for metric_name, scorer in metric_scorers.items():
+                extra_metrics[metric_name] = _metric_or_nan(
+                    metric_name,
+                    scorer,
+                    **metric_kwargs,
+                )
+
             return BenchmarkResult(
                 name=name,
                 dataset=dataset,
                 pi=pi,
                 c=c,
                 n_samples=n_samples,
+                problem_type=problem_type,
                 f1=f1,
                 roc_auc=auc,
                 fit_time_s=fit_time,
                 predict_time_s=predict_time,
+                extra_metrics=extra_metrics,
+                warnings=result_warnings,
                 error=None,
             )
 
@@ -574,5 +670,7 @@ class BenchmarkRunner:
                 pi=pi,
                 c=c,
                 n_samples=n_samples,
+                problem_type=problem_type,
+                warnings=result_warnings,
                 error=str(exc),
             )

--- a/tests/test_benchmark_leaderboard.py
+++ b/tests/test_benchmark_leaderboard.py
@@ -1,0 +1,164 @@
+"""Tests for static benchmark leaderboard exports."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+
+import pytest
+from sklearn.linear_model import LogisticRegression
+
+from pulearn import ElkanotoPuClassifier
+from pulearn.benchmarks import (
+    LEADERBOARD_SCHEMA_VERSION,
+    BenchmarkResult,
+    BenchmarkRunner,
+    build_leaderboard_document,
+    iter_leaderboard_csv_rows,
+    leaderboard_metric_scorers,
+    validate_leaderboard_document,
+    write_leaderboard_csv,
+    write_leaderboard_json,
+)
+
+
+def _build_elkanoto():
+    return ElkanotoPuClassifier(
+        estimator=LogisticRegression(max_iter=200, random_state=0),
+        hold_out_ratio=0.1,
+        random_state=0,
+    )
+
+
+def _runner_with_result():
+    runner = BenchmarkRunner(random_state=42)
+    runner.run(
+        estimator_builders={"elkanoto": _build_elkanoto},
+        n_samples=200,
+        pi=0.3,
+        c=0.5,
+        metric_scorers=leaderboard_metric_scorers(),
+    )
+    return runner
+
+
+def test_build_leaderboard_document_top_level_shape():
+    runner = _runner_with_result()
+    doc = build_leaderboard_document(
+        runner,
+        commit_sha="abc123",
+        generated_at="2026-01-01T00:00:00Z",
+    )
+
+    assert doc["schema_version"] == LEADERBOARD_SCHEMA_VERSION
+    assert doc["commit_sha"] == "abc123"
+    assert doc["generated_at"] == "2026-01-01T00:00:00Z"
+    assert doc["problem_types"] == ["PU_SCAR"]
+    assert "environment" in doc
+    assert len(doc["results"]) == 1
+
+
+def test_leaderboard_row_distinguishes_corrected_and_oracle_metrics():
+    runner = _runner_with_result()
+    doc = build_leaderboard_document(runner)
+    row = doc["results"][0]
+
+    assert row["problem_type"] == "PU_SCAR"
+    assert "metrics" in row
+    metrics = row["metrics"]
+    assert set(metrics) == {
+        "pu_f1",
+        "pu_roc_auc",
+        "pu_average_precision",
+        "oracle_f1",
+        "oracle_roc_auc",
+    }
+    assert math.isfinite(metrics["oracle_f1"])
+    assert math.isfinite(metrics["oracle_roc_auc"])
+    assert metrics["pu_f1"] is None or math.isfinite(metrics["pu_f1"])
+
+
+def test_validate_leaderboard_document_rejects_missing_row_key():
+    runner = _runner_with_result()
+    doc = build_leaderboard_document(runner)
+    del doc["results"][0]["problem_type"]
+
+    with pytest.raises(ValueError, match="problem_type"):
+        validate_leaderboard_document(doc)
+
+
+def test_leaderboard_json_writes_standard_json_without_nan(tmp_path):
+    runner = BenchmarkRunner(random_state=42)
+    runner._results.append(
+        BenchmarkResult(
+            name="broken",
+            dataset="synthetic",
+            pi=0.3,
+            c=0.5,
+            n_samples=10,
+            warnings=["diagnostic warning"],
+            error="failed",
+        )
+    )
+    path = tmp_path / "latest.json"
+
+    doc = build_leaderboard_document(runner, commit_sha="abc123")
+    write_leaderboard_json(doc, str(path))
+
+    loaded = json.loads(path.read_text())
+    assert loaded == doc
+    row = loaded["results"][0]
+    assert row["metrics"]["oracle_f1"] is None
+    assert row["warnings"] == ["diagnostic warning"]
+    assert row["error"] == "failed"
+
+
+def test_leaderboard_csv_writes_flat_rows(tmp_path):
+    runner = _runner_with_result()
+    path = tmp_path / "latest.csv"
+
+    doc = build_leaderboard_document(runner, commit_sha="abc123")
+    write_leaderboard_csv(doc, str(path))
+
+    with path.open(newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == len(doc["results"])
+    row = rows[0]
+    assert row["problem_type"] == "PU_SCAR"
+    assert "pu_f1" in row
+    assert "oracle_f1" in row
+    assert "warnings" in row
+
+
+def test_iter_leaderboard_csv_rows_uses_existing_document():
+    runner = _runner_with_result()
+    doc = build_leaderboard_document(runner)
+
+    rows = list(iter_leaderboard_csv_rows(doc))
+
+    assert len(rows) == 1
+    assert rows[0]["name"] == "elkanoto"
+    assert rows[0]["problem_type"] == "PU_SCAR"
+
+
+def test_leaderboard_metric_scorers_compute_expected_toy_values():
+    scorers = leaderboard_metric_scorers()
+    kwargs = {
+        "y_true": [1, 0],
+        "y_pu": [1, 0],
+        "y_pred": [1, 0],
+        "y_score": [0.5, 0.5],
+        "pi": 0.5,
+        "c": 0.5,
+    }
+
+    assert scorers["pu_f1"](**kwargs) == pytest.approx(1.0)
+    assert scorers["pu_roc_auc"](**kwargs) == pytest.approx(0.5)
+    assert scorers["pu_average_precision"](**kwargs) == pytest.approx(0.5)
+
+
+def test_leaderboard_functions_exported_from_package():
+    from pulearn.benchmarks import write_leaderboard_json as exported
+
+    assert exported is write_leaderboard_json

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -79,6 +79,18 @@ def test_benchmark_result_error_defaults_none():
     assert r.as_dict()["error"] == ""
 
 
+def test_benchmark_result_as_dict_keeps_structured_warnings():
+    r = BenchmarkResult(
+        name="x",
+        dataset="d",
+        pi=0.3,
+        c=0.5,
+        n_samples=10,
+        warnings=["first", "second"],
+    )
+    assert r.as_dict()["warnings"] == ["first", "second"]
+
+
 # ---------------------------------------------------------------------------
 # BenchmarkRunner.run — smoke (quick)
 # ---------------------------------------------------------------------------
@@ -207,6 +219,25 @@ def test_runner_with_prebuilt_data():
     assert len(runner.results) == len(_BUILDERS)
     for r in runner.results:
         assert r.dataset == "prebuilt"
+
+
+def test_runner_stores_realized_labeling_propensity_for_prebuilt_data():
+    X, y_true, y_pu = make_pu_dataset(
+        n_samples=200, pi=0.3, c=0.5, random_state=5
+    )
+    realized_c = float(((y_true == 1) & (y_pu == 1)).sum() / y_true.sum())
+    runner = BenchmarkRunner(random_state=42)
+    runner.run(
+        estimator_builders=_BUILDERS,
+        X=X,
+        y_true=y_true,
+        y_pu=y_pu,
+        dataset_name="prebuilt",
+        c=0.99,
+    )
+
+    for r in runner.results:
+        assert r.c == pytest.approx(realized_c)
 
 
 # ---------------------------------------------------------------------------
@@ -460,6 +491,42 @@ def test_runner_roc_auc_single_class_test():
     r = runner.results[0]
     assert r.error is None
     assert np.isnan(r.roc_auc)
+
+
+def test_runner_custom_metric_scorer_is_stored_in_extra_metrics():
+    def _toy_metric(**kwargs):
+        return float(np.mean(kwargs["y_pred"]))
+
+    runner = BenchmarkRunner(random_state=42)
+    runner.run(
+        estimator_builders=_BUILDERS,
+        n_samples=200,
+        pi=0.3,
+        c=0.5,
+        metric_scorers={"toy_metric": _toy_metric},
+    )
+
+    for r in runner.results:
+        assert "toy_metric" in r.extra_metrics
+        assert np.isfinite(r.extra_metrics["toy_metric"])
+
+
+def test_runner_custom_metric_value_error_becomes_warning_and_nan():
+    def _broken_metric(**kwargs):
+        raise ValueError("metric unavailable")
+
+    runner = BenchmarkRunner(random_state=42)
+    runner.run(
+        estimator_builders={"elkanoto_lr": _build_lr_elkanoto},
+        n_samples=200,
+        pi=0.3,
+        c=0.5,
+        metric_scorers={"broken_metric": _broken_metric},
+    )
+
+    r = runner.results[0]
+    assert np.isnan(r.extra_metrics["broken_metric"])
+    assert any("metric unavailable" in warning for warning in r.warnings)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_experiment_config.py
+++ b/tests/test_experiment_config.py
@@ -341,6 +341,41 @@ def test_save_run_artifacts_results_csv_rows_match_runner(tmp_path):
     assert len(rows) == len(runner.results)
 
 
+def test_save_run_artifacts_flattens_extra_metrics_in_csv(tmp_path):
+    import numpy as np
+    from sklearn.base import BaseEstimator, ClassifierMixin
+
+    class _StableEstimator(BaseEstimator, ClassifierMixin):
+        def fit(self, X, y):
+            self.classes_ = np.array([0, 1])
+            return self
+
+        def predict_proba(self, X):
+            return np.tile([0.4, 0.6], (len(X), 1))
+
+    cfg = _minimal_config()
+    runner = BenchmarkRunner(random_state=cfg.seed)
+    runner.run(
+        {"stable": _StableEstimator},
+        n_samples=100,
+        pi=cfg.pi,
+        c=cfg.c,
+        metric_scorers={"toy_metric": lambda **_kwargs: 0.25},
+    )
+    run_dir = save_run_artifacts(
+        runner, cfg, results_dir=str(tmp_path), run_id="extra_metrics"
+    )
+
+    with open(os.path.join(run_dir, "results.csv"), newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    assert rows[0]["toy_metric"] == "0.2500"
+
+    with open(os.path.join(run_dir, "summary.json")) as fh:
+        summary = json.load(fh)
+    assert summary["results"][0]["extra_metrics"] == {"toy_metric": 0.25}
+    assert isinstance(summary["results"][0]["warnings"], list)
+
+
 def test_save_run_artifacts_summary_json_has_all_sections(tmp_path):
     cfg = _minimal_config()
     runner = BenchmarkRunner(random_state=cfg.seed)


### PR DESCRIPTION
## Planning source

Refs #213.

This is the first implementation slice for the static latest leaderboard MVP: publish machine-readable benchmark outputs from the existing benchmark harness and nightly workflow. It intentionally does not add the rendered GitHub Pages leaderboard UI yet; that remains the next slice.

No open GitHub milestone is currently available for this repo, so no milestone was assigned.

## What changed

- Added `pulearn.benchmarks.leaderboard` with a versioned leaderboard JSON document schema and flattened CSV export.
- Extended `BenchmarkResult` with corrected PU metrics, `problem_type`, and captured row warnings while preserving existing `f1` / `roc_auc` fields for benchmark-oracle compatibility.
- Distinguished corrected PU metrics (`pu_*`) from benchmark-oracle metrics (`oracle_*`) in leaderboard output.
- Exported the leaderboard helpers from `pulearn.benchmarks`.
- Updated the nightly benchmark workflow to upload:
  - `benchmark_results.csv`
  - `leaderboard/latest.json`
  - `leaderboard/latest.csv`
- Documented the new nightly leaderboard artifacts in the benchmark gating policy.
- Added focused tests for schema validation, JSON serialization without NaN, CSV flattening, package exports, and metric naming separation.

## Validation

- `python -m pytest tests/test_benchmark_runner.py tests/test_benchmark_leaderboard.py tests/test_benchmark_smoke_gate.py -q --no-cov`
- `python -m pytest --no-cov`
- `ruff check src/pulearn/benchmarks tests/test_benchmark_leaderboard.py tests/test_benchmark_runner.py`
- `ruff format --check src/pulearn/benchmarks/runner.py src/pulearn/benchmarks/leaderboard.py src/pulearn/benchmarks/__init__.py tests/test_benchmark_leaderboard.py`
- Local smoke export wrote and read `leaderboard/latest.json` and `leaderboard/latest.csv` successfully.

## Follow-up

- Add the rendered static GitHub Pages leaderboard page.
- Decide whether historical immutable run artifacts belong in this issue or a follow-up issue.
