### PR TITLE
Add static benchmark leaderboard site

### DIFF
--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -190,3 +190,30 @@ jobs:
             leaderboard/latest.json
             leaderboard/latest.csv
           if-no-files-found: ignore
+
+  publish-leaderboard:
+    name: Publish leaderboard data
+    needs: benchmark-nightly
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
+    steps:
+      - name: Download Python 3.12 leaderboard artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: benchmark-results-py3.12
+          path: public-leaderboard
+
+      - name: Verify leaderboard files
+        run: |
+          test -s public-leaderboard/leaderboard/latest.json
+          test -s public-leaderboard/leaderboard/latest.csv
+
+      - name: Publish latest leaderboard data to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: public-leaderboard/leaderboard
+          destination_dir: leaderboard
+          keep_files: true

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,8 @@ Positive-unlabeled learning with Python.
 
 **Documentation:** `https://pulearn.github.io/pulearn/doc/pulearn/ <https://pulearn.github.io/pulearn/doc/pulearn/>`_
 
+**Benchmark leaderboard:** `https://pulearn.github.io/pulearn/doc/pulearn/leaderboard/ <https://pulearn.github.io/pulearn/doc/pulearn/leaderboard/>`_
+
 
 .. code-block:: python
 
@@ -49,6 +51,9 @@ in the ``doc/`` directory:
   sensitivity analysis.
 - `Failure-Mode Playbook <doc/guide_failure_modes.md>`_ — common ``UserWarning``
   messages with root causes and mitigations, plus a debug checklist.
+- `Benchmark Leaderboard <https://pulearn.github.io/pulearn/doc/pulearn/leaderboard/>`_
+  — latest nightly benchmark snapshot with corrected PU metrics, benchmark
+  oracle metrics, warnings, and raw JSON/CSV links.
 
 
 End-to-End Example

--- a/doc/README.md
+++ b/doc/README.md
@@ -7,3 +7,7 @@ Build HTML documentation by running:
 ```
 
 The docs will appear in _./build_ directory.
+
+The build also copies `doc/leaderboard.html` to
+`doc/build/pulearn/leaderboard/index.html`, which is published at
+<https://pulearn.github.io/pulearn/doc/pulearn/leaderboard/>.

--- a/doc/benchmark_gating_policy.md
+++ b/doc/benchmark_gating_policy.md
@@ -98,6 +98,16 @@ The same artifact also contains static leaderboard exports:
   benchmark-oracle metrics, warnings, and errors.
 - `leaderboard/latest.csv` — flattened CSV view of the same leaderboard rows.
 
+After the full nightly matrix succeeds on `master`, the Python 3.12
+leaderboard exports are also published to GitHub Pages:
+
+- <https://pulearn.github.io/pulearn/leaderboard/latest.json>
+- <https://pulearn.github.io/pulearn/leaderboard/latest.csv>
+
+The static leaderboard page is published with the docs site at
+<https://pulearn.github.io/pulearn/doc/pulearn/leaderboard/> and reads the
+latest JSON document from the public GitHub Pages artifact path.
+
 The `pu_*` metric columns are corrected PU metrics computed on the held-out
 PU labels. The `oracle_*` metric columns use benchmark ground-truth labels and
 are intended for controlled benchmark diagnostics, not for deployable PU

--- a/doc/build.sh
+++ b/doc/build.sh
@@ -25,6 +25,12 @@ PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}src" pdoc3 --html \
      pulearn
 popd >/dev/null
 
+echo
+echo 'Adding static leaderboard page'
+echo
+mkdir -p "$BUILDROOT/pulearn/leaderboard"
+cp "$DOCROOT/leaderboard.html" "$BUILDROOT/pulearn/leaderboard/index.html"
+
 
 # if [ "$IS_RELEASE" ]; then
 #     echo -e '\nAdding GAnalytics code\n'

--- a/doc/leaderboard.html
+++ b/doc/leaderboard.html
@@ -1,0 +1,461 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PUlearn Benchmark Leaderboard</title>
+  <link rel="icon" href="https://pulearn.github.io/pulearn/logo.png">
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --ink: #1f2933;
+      --muted: #5f6c7b;
+      --line: #d9e0e8;
+      --accent: #0f766e;
+      --accent-strong: #0b4f4a;
+      --warn: #8a4b0f;
+      --error: #a61b1b;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family:
+        -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }
+
+    header,
+    main {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+    }
+
+    header {
+      padding: 28px 0 20px;
+    }
+
+    .topline {
+      display: flex;
+      gap: 14px;
+      align-items: center;
+      margin-bottom: 18px;
+    }
+
+    .topline img {
+      width: 44px;
+      height: 44px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 2.1rem;
+      line-height: 1.1;
+    }
+
+    .lede {
+      max-width: 780px;
+      margin: 0;
+      color: var(--muted);
+      font-size: 1.03rem;
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 18px;
+    }
+
+    a.button {
+      display: inline-flex;
+      align-items: center;
+      min-height: 38px;
+      padding: 8px 13px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      color: var(--accent-strong);
+      background: var(--panel);
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    a.button:hover {
+      border-color: var(--accent);
+    }
+
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin: 20px 0;
+    }
+
+    .stat,
+    .notice,
+    .table-wrap,
+    .definitions {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+    }
+
+    .stat {
+      padding: 14px;
+    }
+
+    .stat-label {
+      display: block;
+      color: var(--muted);
+      font-size: 0.82rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .stat-value {
+      display: block;
+      margin-top: 4px;
+      font-size: 1.05rem;
+      font-weight: 700;
+      word-break: break-word;
+    }
+
+    .notice {
+      padding: 14px 16px;
+      margin: 18px 0;
+      color: var(--muted);
+    }
+
+    .notice strong {
+      color: var(--ink);
+    }
+
+    .notice.error {
+      color: var(--error);
+      border-color: #e6a8a8;
+      background: #fff7f7;
+    }
+
+    .table-wrap {
+      overflow: auto;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 920px;
+    }
+
+    th,
+    td {
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+      white-space: nowrap;
+    }
+
+    th {
+      position: sticky;
+      top: 0;
+      background: #edf3f2;
+      color: #183633;
+      font-size: 0.83rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    td.numeric {
+      text-align: right;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .status-ok {
+      color: var(--accent-strong);
+      font-weight: 700;
+    }
+
+    .status-error {
+      color: var(--error);
+      font-weight: 700;
+    }
+
+    .warning {
+      color: var(--warn);
+      white-space: normal;
+      max-width: 360px;
+    }
+
+    .definitions {
+      margin: 20px 0 36px;
+      padding: 16px;
+    }
+
+    .definitions h2 {
+      margin: 0 0 10px;
+      font-size: 1.15rem;
+    }
+
+    .definitions dl {
+      display: grid;
+      grid-template-columns: 180px 1fr;
+      gap: 8px 16px;
+      margin: 0;
+    }
+
+    .definitions dt {
+      font-weight: 700;
+    }
+
+    .definitions dd {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    code {
+      background: #eef2f5;
+      border-radius: 4px;
+      padding: 1px 4px;
+    }
+
+    @media (max-width: 760px) {
+      header,
+      main {
+        width: min(100% - 20px, 1180px);
+      }
+
+      .summary,
+      .definitions dl {
+        grid-template-columns: 1fr;
+      }
+
+      h1 {
+        font-size: 1.65rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="topline">
+      <img src="https://pulearn.github.io/pulearn/logo.png" alt="">
+      <h1>PUlearn Benchmark Leaderboard</h1>
+    </div>
+    <p class="lede">
+      Latest nightly benchmark snapshot for positive-unlabeled learning
+      estimators. Corrected PU metrics are shown separately from benchmark
+      oracle metrics computed with held-out ground-truth labels.
+    </p>
+    <div class="actions">
+      <a class="button" href="/pulearn/leaderboard/latest.json">JSON</a>
+      <a class="button" href="/pulearn/leaderboard/latest.csv">CSV</a>
+      <a class="button" href="/pulearn/doc/pulearn/">API docs</a>
+      <a class="button" href="https://github.com/pulearn/pulearn/actions/workflows/benchmark-nightly.yml">Nightly workflow</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="summary" aria-label="Run summary">
+      <div class="stat">
+        <span class="stat-label">Generated</span>
+        <span class="stat-value" id="generated-at">Loading</span>
+      </div>
+      <div class="stat">
+        <span class="stat-label">Commit</span>
+        <span class="stat-value" id="commit-sha">Loading</span>
+      </div>
+      <div class="stat">
+        <span class="stat-label">Environment</span>
+        <span class="stat-value" id="environment">Loading</span>
+      </div>
+      <div class="stat">
+        <span class="stat-label">Rows</span>
+        <span class="stat-value" id="row-count">Loading</span>
+      </div>
+    </section>
+
+    <section class="notice" id="assumption-note">
+      <strong>Evaluation note:</strong>
+      <code>pu_*</code> columns are corrected PU metrics computed from PU
+      labels and benchmark assumptions. <code>oracle_*</code> columns use
+      benchmark ground-truth labels for diagnostics and are not deployable PU
+      evaluation metrics.
+    </section>
+
+    <section class="notice" id="loading-note">Loading latest leaderboard data.</section>
+
+    <section class="table-wrap" aria-label="Leaderboard results">
+      <table>
+        <thead>
+          <tr>
+            <th>Estimator</th>
+            <th>Dataset</th>
+            <th>Problem</th>
+            <th>pi</th>
+            <th>c</th>
+            <th>PU F1</th>
+            <th>PU ROC-AUC</th>
+            <th>PU AP</th>
+            <th>Oracle F1</th>
+            <th>Oracle ROC-AUC</th>
+            <th>Fit s</th>
+            <th>Predict s</th>
+            <th>Status</th>
+            <th>Warnings</th>
+          </tr>
+        </thead>
+        <tbody id="leaderboard-body">
+          <tr>
+            <td colspan="14">Loading latest leaderboard data.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="definitions">
+      <h2>Metric Definitions</h2>
+      <dl id="metric-definitions">
+        <dt>Loading</dt>
+        <dd>Metric definitions are loaded from the leaderboard schema.</dd>
+      </dl>
+    </section>
+  </main>
+
+  <script>
+    const DATA_URL = "/pulearn/leaderboard/latest.json";
+
+    function text(value, fallback = "n/a") {
+      if (value === null || value === undefined || value === "") {
+        return fallback;
+      }
+      return String(value);
+    }
+
+    function number(value) {
+      if (value === null || value === undefined || Number.isNaN(value)) {
+        return "n/a";
+      }
+      return Number(value).toFixed(4);
+    }
+
+    function shortSha(value) {
+      if (!value) {
+        return "n/a";
+      }
+      return String(value).slice(0, 7);
+    }
+
+    function setText(id, value) {
+      document.getElementById(id).textContent = value;
+    }
+
+    function renderRows(rows) {
+      const body = document.getElementById("leaderboard-body");
+      body.replaceChildren();
+      if (!rows.length) {
+        const tr = document.createElement("tr");
+        const td = document.createElement("td");
+        td.colSpan = 14;
+        td.textContent = "No benchmark rows are available.";
+        tr.appendChild(td);
+        body.appendChild(tr);
+        return;
+      }
+
+      for (const row of rows) {
+        const metrics = row.metrics || {};
+        const timing = row.timing || {};
+        const values = [
+          text(row.name),
+          text(row.dataset),
+          text(row.problem_type),
+          number(row.pi),
+          number(row.c),
+          number(metrics.pu_f1),
+          number(metrics.pu_roc_auc),
+          number(metrics.pu_average_precision),
+          number(metrics.oracle_f1),
+          number(metrics.oracle_roc_auc),
+          number(timing.fit_time_s),
+          number(timing.predict_time_s),
+        ];
+        const tr = document.createElement("tr");
+        values.forEach((value, index) => {
+          const td = document.createElement("td");
+          td.textContent = value;
+          if (index >= 3) {
+            td.className = "numeric";
+          }
+          tr.appendChild(td);
+        });
+
+        const status = document.createElement("td");
+        status.textContent = row.error ? "Error" : "OK";
+        status.className = row.error ? "status-error" : "status-ok";
+        tr.appendChild(status);
+
+        const warnings = document.createElement("td");
+        const warningText = row.error || (row.warnings || []).join(" | ");
+        warnings.textContent = warningText || "";
+        warnings.className = warningText ? "warning" : "";
+        tr.appendChild(warnings);
+
+        body.appendChild(tr);
+      }
+    }
+
+    function renderDefinitions(definitions) {
+      const dl = document.getElementById("metric-definitions");
+      dl.replaceChildren();
+      Object.entries(definitions || {}).forEach(([name, spec]) => {
+        const dt = document.createElement("dt");
+        dt.textContent = name;
+        const dd = document.createElement("dd");
+        dd.textContent = `${spec.kind}: ${spec.description}`;
+        dl.appendChild(dt);
+        dl.appendChild(dd);
+      });
+    }
+
+    async function loadLeaderboard() {
+      const loading = document.getElementById("loading-note");
+      try {
+        const response = await fetch(DATA_URL, { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const documentData = await response.json();
+        const env = documentData.environment || {};
+        setText("generated-at", text(documentData.generated_at));
+        setText("commit-sha", shortSha(documentData.commit_sha));
+        setText(
+          "environment",
+          `Python ${text(env.python_version).split(" ")[0]}, sklearn ${text(env.sklearn_version)}`
+        );
+        setText("row-count", String((documentData.results || []).length));
+        renderRows(documentData.results || []);
+        renderDefinitions(documentData.metric_definitions || {});
+        loading.textContent = "Loaded latest benchmark snapshot.";
+      } catch (error) {
+        loading.className = "notice error";
+        loading.textContent =
+          "Could not load /pulearn/leaderboard/latest.json. " +
+          "The nightly workflow may not have published a snapshot yet.";
+        setText("generated-at", "Unavailable");
+        setText("commit-sha", "Unavailable");
+        setText("environment", "Unavailable");
+        setText("row-count", "0");
+      }
+    }
+
+    loadLeaderboard();
+  </script>
+</body>
+</html>

--- a/tests/test_docs_leaderboard.py
+++ b/tests/test_docs_leaderboard.py
@@ -1,0 +1,37 @@
+"""Tests for the static benchmark leaderboard documentation page."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_leaderboard_page_fetches_public_latest_json():
+    html = (ROOT / "doc" / "leaderboard.html").read_text(encoding="utf-8")
+
+    assert "PUlearn Benchmark Leaderboard" in html
+    assert 'const DATA_URL = "/pulearn/leaderboard/latest.json";' in html
+    assert 'href="/pulearn/leaderboard/latest.csv"' in html
+    assert "pu_average_precision" in html
+    assert "oracle_roc_auc" in html
+
+
+def test_docs_build_copies_leaderboard_page():
+    build_script = (ROOT / "doc" / "build.sh").read_text(encoding="utf-8")
+
+    assert 'mkdir -p "$BUILDROOT/pulearn/leaderboard"' in build_script
+    assert (
+        'cp "$DOCROOT/leaderboard.html" '
+        '"$BUILDROOT/pulearn/leaderboard/index.html"'
+    ) in build_script
+
+
+def test_nightly_workflow_publishes_leaderboard_data_after_matrix_success():
+    workflow = (
+        ROOT / ".github" / "workflows" / "benchmark-nightly.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "publish-leaderboard:" in workflow
+    assert "needs: benchmark-nightly" in workflow
+    assert "benchmark-results-py3.12" in workflow
+    assert "destination_dir: leaderboard" in workflow
+    assert "publish_dir: public-leaderboard/leaderboard" in workflow


### PR DESCRIPTION
## Summary

Closes #213.

Adds the site-facing half of the benchmark leaderboard work:

- adds a static leaderboard page under the published pdoc docs path at `/doc/pulearn/leaderboard/`
- renders run metadata, corrected PU metrics, benchmark-oracle metrics, warnings, errors, and metric definitions from `latest.json`
- links the page from the README and documents the published JSON/CSV endpoints
- copies the static page into `doc/build/pulearn/leaderboard/index.html` during the docs build
- publishes the Python 3.12 nightly leaderboard JSON/CSV to the stable GitHub Pages `/leaderboard/` path after the full benchmark matrix succeeds

## Why

PR #231 added the machine-readable leaderboard exports. This PR exposes those exports as a public mini site and gives the nightly workflow a stable Pages destination for the latest JSON/CSV data.

## Validation

- `python -m pytest tests/test_docs_leaderboard.py tests/test_benchmark_leaderboard.py -q --no-cov`
- `python -m pytest -q`
- `ruff check tests/test_docs_leaderboard.py src/pulearn/benchmarks tests/test_benchmark_leaderboard.py`
- `ruff format --check tests/test_docs_leaderboard.py`
- `python - <<'PY' ... yaml.safe_load(...) ... PY` for `.github/workflows/benchmark-nightly.yml`
- `bash doc/build.sh`
- Playwright-rendered the built page at the generated docs route and in a simulated GitHub Pages tree with sample `/pulearn/leaderboard/latest.json` data

## Notes

- The public page initially shows a fallback message until the next successful nightly/manual benchmark run publishes `latest.json`.
- Historical leaderboard runs remain a separate follow-up from Option 2; this PR is the static latest-snapshot site.

## Milestone

No open GitHub milestones are available for this repository, so none was assigned.
